### PR TITLE
Add a preliminary fix for desired stat preview

### DIFF
--- a/src/components/PatchNotes/patchNotesData.ts
+++ b/src/components/PatchNotes/patchNotesData.ts
@@ -11,6 +11,21 @@ export type PatchNote = {
 
 export const PatchNotes: PatchNote[] = [
 	{
+		date: '2023-04-03',
+		version: '1.3.3',
+		title: 'Fix desired stat preview',
+		sections: [
+			{
+				items: [
+					`Fixed an issue where the desired stat preview would show a tier as unachievable when in reality it was achievable.
+					Note that this was just a visual bug and that clicking on the "unachievable" tier would still work. This fix is a bit of a hack
+					and will still result in buggy desired stat preview behavior if the user selects expensive mods.
+					`,
+				],
+			},
+		],
+	},
+	{
 		date: '2023-03-31',
 		version: '1.3.2',
 		title: 'Fix melee ability bug',

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -69,6 +69,7 @@ import { EModId } from '@dlb/generated/mod/EModId';
 import { getArmorSlotModViolations } from '@dlb/types/ModViolation';
 import { DestinyClassHashToDestinyClass } from '@dlb/types/External';
 import { EElementId } from '@dlb/types/IdEnums';
+import { ARTIFICE_BONUS_VALUE } from '@dlb/utils/item-utils';
 
 export function makeStore() {
 	return configureStore({
@@ -301,7 +302,8 @@ function handleChange() {
 				// tiers that aren't actually possible.
 				const possibleStat =
 					result.metadata.totalArmorStatMapping[armorStatId] +
-					10 * availableMods;
+					10 * availableMods +
+					ARTIFICE_BONUS_VALUE * result.numUnusedArtificeMods;
 				if (possibleStat > maxPossibleStats[armorStatId]) {
 					maxPossibleStats[armorStatId] = possibleStat;
 				}

--- a/src/services/tests/getRequiredArmorStatMods.test.ts
+++ b/src/services/tests/getRequiredArmorStatMods.test.ts
@@ -2,6 +2,7 @@ import { EModId } from '@dlb/generated/mod/EModId';
 import {
 	getRequiredArmorStatMods,
 	GetRequiredArmorStatModsParams,
+	RequiredStatMods,
 } from '@dlb/services/armor-processing';
 import {
 	getDefaultArmorMetadata,
@@ -15,7 +16,6 @@ import {
 } from '@dlb/types/IdEnums';
 
 import { describe, expect, test } from '@jest/globals';
-import { count } from 'console';
 
 const defaultArmorMetadataItem = getDefaultArmorMetadata().Warlock;
 
@@ -33,7 +33,7 @@ artificeWarlockMetadatItem.artifice.items.Leg.count = 1;
 type GetRequiredArmorStatModsTestCase = {
 	name: string;
 	input: GetRequiredArmorStatModsParams;
-	output: [EModId[], EModId[], ArmorStatMapping];
+	output: RequiredStatMods;
 };
 
 const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
@@ -55,10 +55,10 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 			numSeenArtificeArmorItems: 0,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			[EModId.MobilityMod],
-			[],
-			{
+		output: {
+			requiredArmorStatModIdList: [EModId.MobilityMod],
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 10,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 0,
@@ -66,7 +66,8 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 0,
 			},
-		],
+			numUnusedArtificeMods: 0,
+		},
 	},
 	{
 		name: 'It returns one major and one minor mobility mod when the only required stat is mobility',
@@ -86,10 +87,10 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 			numSeenArtificeArmorItems: 0,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			[EModId.MobilityMod, EModId.MinorMobilityMod],
-			[],
-			{
+		output: {
+			requiredArmorStatModIdList: [EModId.MobilityMod, EModId.MinorMobilityMod],
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 15,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 0,
@@ -97,7 +98,8 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 0,
 			},
-		],
+			numUnusedArtificeMods: 0,
+		},
 	},
 	{
 		name: 'It returns a ton of stats with a bunch of variations',
@@ -117,8 +119,8 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 			numSeenArtificeArmorItems: 0,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			[
+		output: {
+			requiredArmorStatModIdList: [
 				EModId.MobilityMod,
 				EModId.MinorMobilityMod,
 				EModId.ResilienceMod,
@@ -132,8 +134,8 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				EModId.StrengthMod,
 				EModId.StrengthMod,
 			],
-			[],
-			{
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 15,
 				[EArmorStatId.Resilience]: 10,
 				[EArmorStatId.Recovery]: 60,
@@ -141,7 +143,8 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				[EArmorStatId.Intellect]: 5,
 				[EArmorStatId.Strength]: 20,
 			},
-		],
+			numUnusedArtificeMods: 0,
+		},
 	},
 	{
 		name: 'With three remaining pieces, it returns one mod when the only required stat is 100 mobility',
@@ -161,10 +164,10 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 			numSeenArtificeArmorItems: 0,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			[EModId.MinorMobilityMod],
-			[],
-			{
+		output: {
+			requiredArmorStatModIdList: [EModId.MinorMobilityMod],
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 5,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 0,
@@ -172,7 +175,8 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 0,
 			},
-		],
+			numUnusedArtificeMods: 0,
+		},
 	},
 	{
 		name: 'With two remaining pieces',
@@ -192,15 +196,15 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 			numSeenArtificeArmorItems: 0,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			[
+		output: {
+			requiredArmorStatModIdList: [
 				EModId.MobilityMod,
 				EModId.MobilityMod,
 				EModId.MobilityMod,
 				EModId.MinorRecoveryMod,
 			],
-			[],
-			{
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 30,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 5,
@@ -208,7 +212,8 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 0,
 			},
-		],
+			numUnusedArtificeMods: 0,
+		},
 	},
 	{
 		name: 'With two remaining pieces',
@@ -228,15 +233,15 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 			numSeenArtificeArmorItems: 0,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			[
+		output: {
+			requiredArmorStatModIdList: [
 				EModId.MobilityMod,
 				EModId.MobilityMod,
 				EModId.MobilityMod,
 				EModId.MinorRecoveryMod,
 			],
-			[],
-			{
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 30,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 5,
@@ -244,7 +249,8 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 0,
 			},
-		],
+			numUnusedArtificeMods: 0,
+		},
 	},
 	{
 		name: 'With no remaining pieces, and a mix of artifice and non-artifice armor, it returns the corect combination of armor stat mods and artifice stat mods',
@@ -271,16 +277,19 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				icon: '',
 			},
 		},
-		output: [
-			[
+		output: {
+			requiredArmorStatModIdList: [
 				EModId.ResilienceMod,
 				EModId.ResilienceMod,
 				EModId.RecoveryMod,
 				EModId.RecoveryMod,
 				EModId.RecoveryMod,
 			],
-			[EModId.ResilienceForged, EModId.RecoveryForged],
-			{
+			requiredArtificeModIdList: [
+				EModId.ResilienceForged,
+				EModId.RecoveryForged,
+			],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 0,
 				[EArmorStatId.Resilience]: 20,
 				[EArmorStatId.Recovery]: 30,
@@ -288,7 +297,8 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 0,
 			},
-		],
+			numUnusedArtificeMods: 0,
+		},
 	},
 	{
 		name: 'It properly chooses to replace two minor mods with artifice mods instead of one major mod',
@@ -315,16 +325,20 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				icon: '',
 			},
 		},
-		output: [
-			[
+		output: {
+			requiredArmorStatModIdList: [
 				EModId.MobilityMod,
 				EModId.MinorMobilityMod,
 				EModId.MinorResilienceMod,
 				EModId.MinorDisciplineMod,
 				EModId.MinorStrengthMod,
 			],
-			[EModId.RecoveryForged, EModId.IntellectForged, EModId.IntellectForged],
-			{
+			requiredArtificeModIdList: [
+				EModId.RecoveryForged,
+				EModId.IntellectForged,
+				EModId.IntellectForged,
+			],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 15,
 				[EArmorStatId.Resilience]: 5,
 				[EArmorStatId.Recovery]: 0,
@@ -332,6 +346,7 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 5,
 			},
+			numUnusedArtificeMods: 1,
 			// This would also work. The algorithm doesn't try to use fewer
 			// artifice mods if possible.
 			// [
@@ -350,7 +365,7 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 			// 	[EArmorStatId.Intellect]: 5,
 			// 	[EArmorStatId.Strength]: 5,
 			// },
-		],
+		},
 	},
 	{
 		name: 'With nine mods needed it properly replaces the 4 minor mods with artifice mods',
@@ -377,21 +392,21 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				icon: '',
 			},
 		},
-		output: [
-			[
+		output: {
+			requiredArmorStatModIdList: [
 				EModId.MobilityMod,
 				EModId.ResilienceMod,
 				EModId.RecoveryMod,
 				EModId.DisciplineMod,
 				EModId.IntellectMod,
 			],
-			[
+			requiredArtificeModIdList: [
 				EModId.MobilityForged,
 				EModId.ResilienceForged,
 				EModId.RecoveryForged,
 				EModId.DisciplineForged,
 			],
-			{
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 10,
 				[EArmorStatId.Resilience]: 10,
 				[EArmorStatId.Recovery]: 10,
@@ -399,7 +414,8 @@ const getRequiredArmorStatModsTestCases: GetRequiredArmorStatModsTestCase[] = [
 				[EArmorStatId.Intellect]: 10,
 				[EArmorStatId.Strength]: 0,
 			},
-		],
+			numUnusedArtificeMods: 0,
+		},
 	},
 ];
 

--- a/src/services/tests/processArmor.test.ts
+++ b/src/services/tests/processArmor.test.ts
@@ -156,6 +156,7 @@ const processArmorTestCases: ProcessArmorTestCase[] = [
 				armorIdList: ['0', '1', '2', '3'],
 				armorStatModIdList: [],
 				artificeModIdList: [],
+				numUnusedArtificeMods: 0,
 				metadata: {
 					totalModCost: 0,
 					totalStatTiers: 24,
@@ -263,6 +264,7 @@ const processArmorTestCases: ProcessArmorTestCase[] = [
 					EModId.ResilienceForged,
 					EModId.ResilienceForged,
 				],
+				numUnusedArtificeMods: 2,
 				metadata: {
 					totalModCost: 18,
 					totalStatTiers: 35,
@@ -373,6 +375,7 @@ const processArmorTestCases: ProcessArmorTestCase[] = [
 					EModId.ResilienceForged,
 					EModId.ResilienceForged,
 				],
+				numUnusedArtificeMods: 2,
 				metadata: {
 					totalModCost: 18,
 					totalStatTiers: 35,
@@ -470,6 +473,7 @@ const processArmorTestCases: ProcessArmorTestCase[] = [
 					EModId.MobilityMod,
 				],
 				artificeModIdList: [],
+				numUnusedArtificeMods: 0,
 				metadata: {
 					totalModCost: 15,
 					totalStatTiers: 30,
@@ -574,6 +578,7 @@ const processArmorTestCases: ProcessArmorTestCase[] = [
 					EModId.RecoveryMod,
 				],
 				artificeModIdList: [EModId.ResilienceForged, EModId.RecoveryForged],
+				numUnusedArtificeMods: 0,
 				metadata: {
 					totalModCost: 20,
 					totalStatTiers: 36,
@@ -683,6 +688,7 @@ const processArmorTestCases: ProcessArmorTestCase[] = [
 					EModId.DisciplineForged,
 					EModId.DisciplineForged,
 				],
+				numUnusedArtificeMods: 0,
 				metadata: {
 					totalModCost: 20,
 					totalStatTiers: 37,

--- a/src/services/tests/shouldShortCircuit.test.ts
+++ b/src/services/tests/shouldShortCircuit.test.ts
@@ -70,9 +70,9 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 			armorMetadataItem: defaultArmorMetadata.Warlock,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			true,
-			[
+		output: {
+			shortCircuit: true,
+			requiredArmorStatModIdList: [
 				EModId.MobilityMod,
 				EModId.MobilityMod,
 				EModId.MobilityMod,
@@ -81,12 +81,12 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				EModId.MobilityMod,
 				EModId.MinorMobilityMod,
 			],
-			[],
+			requiredArtificeModIdList: [],
 			// [
 			// 	Array(21).fill(EModId.DisciplineForged),
 			// 	Array(21).fill(EModId.StrengthForged),
 			// ].flat(),
-			{
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 65,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 0,
@@ -94,9 +94,10 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 0,
 			},
-			null,
-			EArmorSlotId.Chest,
-		],
+			numUnusedArtificeMods: 0,
+			armorStat: null,
+			slot: EArmorSlotId.Chest,
+		},
 	},
 	// 1
 	{
@@ -120,16 +121,16 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 			armorMetadataItem: defaultArmorMetadata.Warlock,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			false,
-			[
+		output: {
+			shortCircuit: false,
+			requiredArmorStatModIdList: [
 				EModId.StrengthMod,
 				EModId.StrengthMod,
 				EModId.StrengthMod,
 				EModId.MinorStrengthMod,
 			],
-			[],
-			{
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 0,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 0,
@@ -137,9 +138,10 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 35,
 			},
-			null,
-			null,
-		],
+			numUnusedArtificeMods: 0,
+			armorStat: null,
+			slot: null,
+		},
 	},
 	// 2
 	{
@@ -163,9 +165,9 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 			armorMetadataItem: defaultArmorMetadata.Warlock,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			true,
-			[
+		output: {
+			shortCircuit: true,
+			requiredArmorStatModIdList: [
 				EModId.DisciplineMod,
 				EModId.DisciplineMod,
 				EModId.StrengthMod,
@@ -173,12 +175,12 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				EModId.StrengthMod,
 				EModId.MinorStrengthMod,
 			],
-			[],
+			requiredArtificeModIdList: [],
 			// [
 			// 	Array(21).fill(EModId.DisciplineForged),
 			// 	Array(21).fill(EModId.StrengthForged),
 			// ].flat(),
-			{
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 0,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 0,
@@ -186,9 +188,10 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 35,
 			},
-			null,
-			EArmorSlotId.Arm,
-		],
+			numUnusedArtificeMods: 0,
+			armorStat: null,
+			slot: EArmorSlotId.Arm,
+		},
 	},
 	// 3
 	{
@@ -212,9 +215,9 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 			armorMetadataItem: defaultArmorMetadata.Warlock,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			true,
-			[
+		output: {
+			shortCircuit: true,
+			requiredArmorStatModIdList: [
 				EModId.MinorDisciplineMod,
 				EModId.StrengthMod,
 				EModId.StrengthMod,
@@ -223,12 +226,12 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				EModId.StrengthMod,
 				EModId.MinorStrengthMod,
 			],
-			[],
+			requiredArtificeModIdList: [],
 			// [
 			// 	Array(31).fill(EModId.DisciplineForged),
 			// 	Array(31).fill(EModId.StrengthForged),
 			// ].flat(),
-			{
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 0,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 0,
@@ -236,9 +239,10 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 55,
 			},
-			null,
-			EArmorSlotId.Head,
-		],
+			numUnusedArtificeMods: 0,
+			armorStat: null,
+			slot: EArmorSlotId.Head,
+		},
 	},
 	// 4
 	{
@@ -262,11 +266,11 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 			armorMetadataItem: defaultArmorMetadata.Warlock,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			false,
-			[],
-			[],
-			{
+		output: {
+			shortCircuit: false,
+			requiredArmorStatModIdList: [],
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 0,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 0,
@@ -274,9 +278,10 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 0,
 			},
-			null,
-			null,
-		],
+			numUnusedArtificeMods: 0,
+			armorStat: null,
+			slot: null,
+		},
 	},
 	// 5
 	{
@@ -300,11 +305,11 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 			armorMetadataItem: defaultArmorMetadata.Warlock,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			false,
-			[],
-			[],
-			{
+		output: {
+			shortCircuit: false,
+			requiredArmorStatModIdList: [],
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 0,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 0,
@@ -312,9 +317,10 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 0,
 			},
-			null,
-			null,
-		],
+			numUnusedArtificeMods: 0,
+			armorStat: null,
+			slot: null,
+		},
 	},
 	// 6
 	{
@@ -352,17 +358,17 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 			armorMetadataItem: defaultArmorMetadata.Warlock,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			true,
-			[
+		output: {
+			shortCircuit: true,
+			requiredArmorStatModIdList: [
 				EModId.IntellectMod,
 				EModId.IntellectMod,
 				EModId.IntellectMod,
 				EModId.IntellectMod,
 				EModId.IntellectMod,
 			],
-			[],
-			{
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 0,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 0,
@@ -370,9 +376,10 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				[EArmorStatId.Intellect]: 50,
 				[EArmorStatId.Strength]: 0,
 			},
-			null,
-			null,
-		],
+			numUnusedArtificeMods: 0,
+			armorStat: null,
+			slot: null,
+		},
 	},
 	// 7
 	{
@@ -408,17 +415,17 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 			armorMetadataItem: defaultArmorMetadata.Warlock,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			true,
-			[
+		output: {
+			shortCircuit: true,
+			requiredArmorStatModIdList: [
 				EModId.RecoveryMod,
 				EModId.IntellectMod,
 				EModId.IntellectMod,
 				EModId.IntellectMod,
 				EModId.IntellectMod,
 			],
-			[],
-			{
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 0,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 10,
@@ -426,9 +433,10 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				[EArmorStatId.Intellect]: 40,
 				[EArmorStatId.Strength]: 0,
 			},
-			null,
-			null,
-		],
+			numUnusedArtificeMods: 0,
+			armorStat: null,
+			slot: null,
+		},
 	},
 	// 8
 	{
@@ -477,11 +485,15 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 			armorMetadataItem: defaultArmorMetadata.Warlock,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			true,
-			[EModId.MobilityMod, EModId.RecoveryMod, EModId.MinorIntellectMod],
-			[],
-			{
+		output: {
+			shortCircuit: true,
+			requiredArmorStatModIdList: [
+				EModId.MobilityMod,
+				EModId.RecoveryMod,
+				EModId.MinorIntellectMod,
+			],
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 10,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 10,
@@ -489,9 +501,10 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				[EArmorStatId.Intellect]: 5,
 				[EArmorStatId.Strength]: 0,
 			},
-			null,
-			null,
-		],
+			numUnusedArtificeMods: 0,
+			armorStat: null,
+			slot: null,
+		},
 	},
 	// 9
 	{
@@ -540,11 +553,11 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 			armorMetadataItem: defaultArmorMetadata.Warlock,
 			selectedExotic: getDefaultAvailableExoticArmorItem(),
 		},
-		output: [
-			false,
-			[EModId.MobilityMod, EModId.RecoveryMod],
-			[],
-			{
+		output: {
+			shortCircuit: false,
+			requiredArmorStatModIdList: [EModId.MobilityMod, EModId.RecoveryMod],
+			requiredArtificeModIdList: [],
+			requiredArmorStatModsArmorStatMapping: {
 				[EArmorStatId.Mobility]: 10,
 				[EArmorStatId.Resilience]: 0,
 				[EArmorStatId.Recovery]: 10,
@@ -552,9 +565,10 @@ const shouldShortCircuitTestCases: ShouldShortCircuitTestCase[] = [
 				[EArmorStatId.Intellect]: 0,
 				[EArmorStatId.Strength]: 0,
 			},
-			null,
-			null,
-		],
+			numUnusedArtificeMods: 0,
+			armorStat: null,
+			slot: null,
+		},
 	},
 ];
 


### PR DESCRIPTION
Previously, unused artifice mods were not counting towards the desired stat tiers. This fixes that with the caveat that it will still have buggy behaviour when the user selects a lot of armor stat mods